### PR TITLE
Integrate ELK stack and Beats

### DIFF
--- a/sonet/deployment/kubernetes/README.md
+++ b/sonet/deployment/kubernetes/README.md
@@ -1,0 +1,20 @@
+# Kubernetes Observability for Sonet
+
+Namespace: `sonet-observability`
+
+Apply manifests:
+```bash
+kubectl apply -f elk-core.yaml
+kubectl apply -f beats-filebeat-daemonset.yaml
+kubectl apply -f beats-metricbeat-daemonset.yaml
+```
+
+Then open Kibana via port-forward or ingress:
+```bash
+kubectl -n sonet-observability port-forward deploy/kibana 5601:5601
+```
+
+- Logs index: `sonet-logs-*`
+- Metrics index: `metricbeat-*`
+
+Filebeat autodiscovers pods and ships to ClusterIP `logstash.sonet-observability.svc:5044`. Metricbeat ships to `elasticsearch.sonet-observability.svc:9200`.

--- a/sonet/deployment/kubernetes/beats-filebeat-daemonset.yaml
+++ b/sonet/deployment/kubernetes/beats-filebeat-daemonset.yaml
@@ -1,0 +1,118 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: sonet-observability
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: filebeat
+  namespace: sonet-observability
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: filebeat
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "namespaces", "nodes"]
+    verbs: ["get", "watch", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: filebeat
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: filebeat
+subjects:
+  - kind: ServiceAccount
+    name: filebeat
+    namespace: sonet-observability
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: filebeat-config
+  namespace: sonet-observability
+  labels:
+    app: filebeat
+    k8s-app: filebeat
+    version: v8
+    managed-by: sonet
+data:
+  filebeat.yml: |
+    filebeat.inputs:
+      - type: container
+        paths:
+          - /var/log/containers/*.log
+        processors:
+          - add_kubernetes_metadata: ~
+    processors:
+      - add_host_metadata: ~
+      - add_process_metadata: ~
+    output.logstash:
+      hosts: ["logstash.sonet-observability.svc:5044"]
+    setup.ilm.enabled: false
+    setup.template.enabled: false
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: filebeat
+  namespace: sonet-observability
+  labels:
+    k8s-app: filebeat
+spec:
+  selector:
+    matchLabels:
+      k8s-app: filebeat
+  template:
+    metadata:
+      labels:
+        k8s-app: filebeat
+    spec:
+      serviceAccountName: filebeat
+      terminationGracePeriodSeconds: 30
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      containers:
+        - name: filebeat
+          image: docker.elastic.co/beats/filebeat:8.13.4
+          args: ["-e", "-c", "/etc/filebeat.yml"]
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          securityContext:
+            runAsUser: 0
+          volumeMounts:
+            - name: config
+              mountPath: /etc/filebeat.yml
+              readOnly: true
+              subPath: filebeat.yml
+            - name: varlog
+              mountPath: /var/log
+              readOnly: true
+            - name: varlibdockercontainers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+            - name: dockersock
+              mountPath: /var/run/docker.sock
+              readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            name: filebeat-config
+            defaultMode: 0640
+        - name: varlog
+          hostPath:
+            path: /var/log
+        - name: varlibdockercontainers
+          hostPath:
+            path: /var/lib/docker/containers
+        - name: dockersock
+          hostPath:
+            path: /var/run/docker.sock

--- a/sonet/deployment/kubernetes/beats-metricbeat-daemonset.yaml
+++ b/sonet/deployment/kubernetes/beats-metricbeat-daemonset.yaml
@@ -1,0 +1,121 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: sonet-observability
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: metricbeat
+  namespace: sonet-observability
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: metricbeat
+rules:
+  - apiGroups: [""]
+    resources: ["nodes", "namespaces", "pods" ]
+    verbs: ["get", "list", "watch"]
+  - nonResourceURLs: ["/metrics", "/metrics/cadvisor"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: metricbeat
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: metricbeat
+subjects:
+  - kind: ServiceAccount
+    name: metricbeat
+    namespace: sonet-observability
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: metricbeat-config
+  namespace: sonet-observability
+  labels:
+    app: metricbeat
+    k8s-app: metricbeat
+    managed-by: sonet
+data:
+  metricbeat.yml: |
+    metricbeat.autodiscover:
+      providers:
+        - type: kubernetes
+          node: ${NODE_NAME}
+          hints.enabled: true
+
+    metricbeat.modules:
+      - module: system
+        period: 10s
+        metricsets: [cpu, load, memory, network, process, process_summary, core, diskio, filesystem, fsstat]
+        processes: ['.*']
+      - module: docker
+        hosts: ["unix:///var/run/docker.sock"]
+        period: 10s
+        enabled: true
+        metricsets: [container, cpu, diskio, event, healthcheck, info, memory, network]
+
+    processors:
+      - add_kubernetes_metadata: ~
+      - add_host_metadata: ~
+
+    output.elasticsearch:
+      hosts: ["http://elasticsearch.sonet-observability.svc:9200"]
+
+    setup.kibana:
+      host: "kibana.sonet-observability.svc:5601"
+
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: metricbeat
+  namespace: sonet-observability
+  labels:
+    k8s-app: metricbeat
+spec:
+  selector:
+    matchLabels:
+      k8s-app: metricbeat
+  template:
+    metadata:
+      labels:
+        k8s-app: metricbeat
+    spec:
+      serviceAccountName: metricbeat
+      terminationGracePeriodSeconds: 30
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      containers:
+        - name: metricbeat
+          image: docker.elastic.co/beats/metricbeat:8.13.4
+          args: ["-e", "-c", "/etc/metricbeat.yml"]
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          securityContext:
+            runAsUser: 0
+          volumeMounts:
+            - name: config
+              mountPath: /etc/metricbeat.yml
+              readOnly: true
+              subPath: metricbeat.yml
+            - name: dockersock
+              mountPath: /var/run/docker.sock
+              readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            name: metricbeat-config
+            defaultMode: 0640
+        - name: dockersock
+          hostPath:
+            path: /var/run/docker.sock

--- a/sonet/deployment/kubernetes/elk-core.yaml
+++ b/sonet/deployment/kubernetes/elk-core.yaml
@@ -1,0 +1,163 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: sonet-observability
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: elasticsearch
+  namespace: sonet-observability
+spec:
+  selector:
+    app: elasticsearch
+  ports:
+    - name: http
+      port: 9200
+      targetPort: 9200
+    - name: transport
+      port: 9300
+      targetPort: 9300
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: elasticsearch
+  namespace: sonet-observability
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: elasticsearch
+  template:
+    metadata:
+      labels:
+        app: elasticsearch
+    spec:
+      containers:
+        - name: elasticsearch
+          image: docker.elastic.co/elasticsearch/elasticsearch:8.13.4
+          env:
+            - name: discovery.type
+              value: single-node
+            - name: xpack.security.enabled
+              value: "false"
+            - name: ES_JAVA_OPTS
+              value: -Xms1g -Xmx1g
+          ports:
+            - containerPort: 9200
+            - containerPort: 9300
+          volumeMounts:
+            - name: es-data
+              mountPath: /usr/share/elasticsearch/data
+      volumes:
+        - name: es-data
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kibana
+  namespace: sonet-observability
+spec:
+  selector:
+    app: kibana
+  ports:
+    - name: http
+      port: 5601
+      targetPort: 5601
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kibana
+  namespace: sonet-observability
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kibana
+  template:
+    metadata:
+      labels:
+        app: kibana
+    spec:
+      containers:
+        - name: kibana
+          image: docker.elastic.co/kibana/kibana:8.13.4
+          env:
+            - name: ELASTICSEARCH_HOSTS
+              value: http://elasticsearch.sonet-observability.svc:9200
+          ports:
+            - containerPort: 5601
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: logstash-pipeline
+  namespace: sonet-observability
+  labels:
+    app: logstash
+    managed-by: sonet
+data:
+  logstash.conf: |
+    input {
+      beats { port => 5044 }
+    }
+    filter {
+      json { source => "message" target => "json" skip_on_invalid_json => true }
+      if ![json] {
+        grok {
+          match => { "message" => ["\\[%{TIMESTAMP_ISO8601:ts}\\] \\[%{LOGLEVEL:level}\\] %{GREEDYDATA:msg}"] }
+          tag_on_failure => []
+        }
+        date { match => ["ts", "YYYY-MM-dd HH:mm:ss.SSS", "YYYY-MM-dd HH:mm:ss,SSS"] target => "@timestamp" remove_field => ["ts"] }
+      } else {
+        mutate { add_field => { "level" => "%{[json][level]}" "msg" => "%{[json][message]}" } remove_field => ["json"] }
+      }
+    }
+    output {
+      elasticsearch { hosts => ["http://elasticsearch.sonet-observability.svc:9200"] index => "sonet-logs-%{+YYYY.MM.dd}" }
+      stdout { codec => rubydebug }
+    }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: logstash
+  namespace: sonet-observability
+spec:
+  selector:
+    app: logstash
+  ports:
+    - name: beats
+      port: 5044
+      targetPort: 5044
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: logstash
+  namespace: sonet-observability
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: logstash
+  template:
+    metadata:
+      labels:
+        app: logstash
+    spec:
+      containers:
+        - name: logstash
+          image: docker.elastic.co/logstash/logstash:8.13.4
+          ports:
+            - containerPort: 5044
+          volumeMounts:
+            - name: pipeline
+              mountPath: /usr/share/logstash/pipeline
+      volumes:
+        - name: pipeline
+          configMap:
+            name: logstash-pipeline

--- a/sonet/docker-compose.yml
+++ b/sonet/docker-compose.yml
@@ -234,11 +234,82 @@ services:
     networks:
       - sonet-network
 
+  # ELK - Elasticsearch
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.13.4
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+      - ES_JAVA_OPTS=-Xms1g -Xmx1g
+    ports:
+      - "9200:9200"
+      - "9300:9300"
+    volumes:
+      - es_data:/usr/share/elasticsearch/data
+    networks:
+      - sonet-network
+
+  # ELK - Kibana
+  kibana:
+    image: docker.elastic.co/kibana/kibana:8.13.4
+    environment:
+      - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
+    ports:
+      - "5601:5601"
+    depends_on:
+      - elasticsearch
+    networks:
+      - sonet-network
+
+  # ELK - Logstash
+  logstash:
+    image: docker.elastic.co/logstash/logstash:8.13.4
+    ports:
+      - "5044:5044"
+    volumes:
+      - ./monitoring/elk/logstash/pipeline:/usr/share/logstash/pipeline
+    depends_on:
+      - elasticsearch
+    networks:
+      - sonet-network
+
+  # Beats - Filebeat (collect Docker logs)
+  filebeat:
+    image: docker.elastic.co/beats/filebeat:8.13.4
+    user: root
+    command: ["-e"]
+    volumes:
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./monitoring/elk/filebeat/filebeat.yml:/usr/share/filebeat/filebeat.yml:ro
+    depends_on:
+      - logstash
+    networks:
+      - sonet-network
+
+  # Beats - Metricbeat (system and docker metrics)
+  metricbeat:
+    image: docker.elastic.co/beats/metricbeat:8.13.4
+    user: root
+    command: ["-e"]
+    volumes:
+      - /proc:/hostfs/proc:ro
+      - /sys/fs/cgroup:/hostfs/sys/fs/cgroup:ro
+      - /:/hostfs:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./monitoring/elk/metricbeat/metricbeat.yml:/usr/share/metricbeat/metricbeat.yml:ro
+    depends_on:
+      - elasticsearch
+      - kibana
+    networks:
+      - sonet-network
+
 volumes:
   postgres_data:
   redis_data:
   prometheus_data:
   grafana_data:
+  es_data:
 
 networks:
   sonet-network:

--- a/sonet/monitoring/elk/README.md
+++ b/sonet/monitoring/elk/README.md
@@ -1,0 +1,23 @@
+# ELK + Beats for Sonet
+
+This directory contains configuration for:
+- Elasticsearch (single-node, security disabled for local dev)
+- Kibana
+- Logstash (pipeline for Beats input and basic parsing)
+- Filebeat (container autodiscover for Docker logs, ships to Logstash)
+- Metricbeat (system and Docker metrics, ships to Elasticsearch)
+
+How to use:
+1. From `sonet/`, run:
+   ```bash
+   docker-compose up -d elasticsearch kibana logstash filebeat metricbeat
+   ```
+2. Access Kibana at http://localhost:5601 and add index patterns:
+   - `sonet-logs-*` for logs
+   - `metricbeat-*` for metrics
+3. Start the rest of the stack (gateway and services). Filebeat will autodiscover containers and ship logs.
+
+Notes:
+- Filebeat uses Docker autodiscover and adds Docker metadata to events.
+- Logstash tries JSON parsing first, then a grok fallback for common spdlog patterns.
+- Metricbeat collects system and Docker metrics. Adjust `metricbeat.yml` for more modules.

--- a/sonet/monitoring/elk/filebeat/filebeat.yml
+++ b/sonet/monitoring/elk/filebeat/filebeat.yml
@@ -1,0 +1,22 @@
+filebeat.autodiscover:
+  providers:
+    - type: docker
+      hints.enabled: true
+      labels.dedot: true
+
+processors:
+  - add_docker_metadata: ~
+  - add_host_metadata: ~
+  - add_process_metadata: ~
+
+logging:
+  level: info
+  metrics:
+    enabled: false
+
+output.logstash:
+  hosts: ["logstash:5044"]
+
+setup:
+  ilm.enabled: false
+  template.enabled: false

--- a/sonet/monitoring/elk/logstash/pipeline/logstash.conf
+++ b/sonet/monitoring/elk/logstash/pipeline/logstash.conf
@@ -1,0 +1,48 @@
+input {
+  beats {
+    port => 5044
+  }
+}
+
+filter {
+  # Add service name from docker metadata when available
+  if [container] and [container][name] {
+    mutate { add_field => { "service.name" => "%{[container][name]}" } }
+  }
+
+  # Try to parse JSON messages directly
+  json {
+    source => "message"
+    target => "json"
+    skip_on_invalid_json => true
+  }
+
+  if ![json] {
+    # Fallback grok for typical spdlog pattern: [ts] [LEVEL] message
+    grok {
+      match => { "message" => ["\\[%{TIMESTAMP_ISO8601:ts}\\] \\[%(?:TRACE|DEBUG|INFO|WARN|ERROR|CRITICAL|OFF)\:]{0,0}\\[%{LOGLEVEL:level}\\] %{GREEDYDATA:msg}", "\\[%{TIMESTAMP_ISO8601:ts}\\] \\[%{LOGLEVEL:level}\\] %{GREEDYDATA:msg}"] }
+      tag_on_failure => []
+    }
+    date {
+      match => ["ts", "YYYY-MM-dd HH:mm:ss.SSS", "YYYY-MM-dd HH:mm:ss,SSS"]
+      target => "@timestamp"
+      remove_field => ["ts"]
+    }
+  } else {
+    mutate {
+      add_field => {
+        "level" => "%{[json][level]}"
+        "msg" => "%{[json][msg]}"
+      }
+      remove_field => ["json"]
+    }
+  }
+}
+
+output {
+  elasticsearch {
+    hosts => ["http://elasticsearch:9200"]
+    index => "sonet-logs-%{+YYYY.MM.dd}"
+  }
+  stdout { codec => rubydebug }
+}

--- a/sonet/monitoring/elk/metricbeat/metricbeat.yml
+++ b/sonet/monitoring/elk/metricbeat/metricbeat.yml
@@ -1,0 +1,46 @@
+metricbeat.modules:
+  - module: system
+    period: 10s
+    metricsets:
+      - cpu
+      - load
+      - memory
+      - network
+      - process
+      - process_summary
+      - socket_summary
+      - core
+      - diskio
+      - filesystem
+      - fsstat
+    processes: ['.*']
+    hostfs: /hostfs
+
+  - module: docker
+    period: 10s
+    hosts: ["unix:///var/run/docker.sock"]
+    enabled: true
+    metricsets:
+      - container
+      - cpu
+      - diskio
+      - event
+      - healthcheck
+      - info
+      - memory
+      - network
+
+processors:
+  - add_docker_metadata: ~
+  - add_host_metadata: ~
+
+logging.level: info
+
+output.elasticsearch:
+  hosts: ["http://elasticsearch:9200"]
+
+setup:
+  ilm.enabled: false
+  template.enabled: true
+  kibana:
+    host: "kibana:5601"

--- a/sonet/src/core/logging/logger.h
+++ b/sonet/src/core/logging/logger.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <spdlog/spdlog.h>
+#include <spdlog/sinks/stdout_color_sinks.h>
+#include <nlohmann/json.hpp>
+#include <cstdlib>
+#include <string>
+#include <memory>
+
+namespace sonet::logging {
+
+inline spdlog::level::level_enum parse_level_from_env(const char* env_key, spdlog::level::level_enum fallback) {
+    const char* value = std::getenv(env_key);
+    if (!value) return fallback;
+    std::string s(value);
+    for (auto& c : s) c = static_cast<char>(std::tolower(c));
+    if (s == "trace") return spdlog::level::trace;
+    if (s == "debug") return spdlog::level::debug;
+    if (s == "info") return spdlog::level::info;
+    if (s == "warn" || s == "warning") return spdlog::level::warn;
+    if (s == "error") return spdlog::level::err;
+    if (s == "critical" || s == "fatal") return spdlog::level::critical;
+    return fallback;
+}
+
+inline std::shared_ptr<spdlog::logger> init_json_stdout_logger(const std::string& service_name_env = "SERVICE_NAME",
+                                                               const std::string& log_level_env = "LOG_LEVEL",
+                                                               const std::string& environment_env = "ENVIRONMENT") {
+    auto sink = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
+    auto logger = std::make_shared<spdlog::logger>("sonet", sink);
+    spdlog::set_default_logger(logger);
+
+    auto level = parse_level_from_env(log_level_env.c_str(), spdlog::level::info);
+    spdlog::set_level(level);
+
+    // Use simple message, we will produce JSON manually in helper functions
+    spdlog::set_pattern("%v");
+
+    return logger;
+}
+
+inline void log_json(spdlog::level::level_enum level,
+                     const std::string& message,
+                     const nlohmann::json& extra = {}) {
+    nlohmann::json j;
+    const char* svc = std::getenv("SERVICE_NAME");
+    const char* env = std::getenv("ENVIRONMENT");
+
+    j["service"] = svc ? svc : "unknown";
+    j["environment"] = env ? env : "development";
+    j["level"] = spdlog::level::to_string_view(level);
+    j["message"] = message;
+    for (auto it = extra.begin(); it != extra.end(); ++it) {
+        j[it.key()] = it.value();
+    }
+
+    switch (level) {
+        case spdlog::level::trace: spdlog::trace(j.dump()); break;
+        case spdlog::level::debug: spdlog::debug(j.dump()); break;
+        case spdlog::level::info: spdlog::info(j.dump()); break;
+        case spdlog::level::warn: spdlog::warn(j.dump()); break;
+        case spdlog::level::err: spdlog::error(j.dump()); break;
+        case spdlog::level::critical: spdlog::critical(j.dump()); break;
+        default: spdlog::info(j.dump()); break;
+    }
+}
+
+} // namespace sonet::logging

--- a/sonet/src/services/follow_service/main.cpp
+++ b/sonet/src/services/follow_service/main.cpp
@@ -16,6 +16,7 @@
 #include <chrono>
 #include <spdlog/spdlog.h>
 #include <nlohmann/json.hpp>
+#include "../../core/logging/logger.h"
 
 using namespace sonet::follow;
 using json = nlohmann::json;
@@ -76,9 +77,8 @@ void setup_signal_handlers() {
 
 // Initialize logging
 void initialize_logging() {
-    spdlog::set_level(spdlog::level::info);
-    spdlog::set_pattern("[%Y-%m-%d %H:%M:%S.%e] [%l] [%t] %v");
-    spdlog::info("Sonet Follow Service logging initialized");
+    (void)sonet::logging::init_json_stdout_logger();
+    spdlog::info(R"({"event":"startup","message":"Sonet Follow Service logging initialized"})");
 }
 
 // Display service information

--- a/sonet/src/services/media_service/main.cpp
+++ b/sonet/src/services/media_service/main.cpp
@@ -10,12 +10,15 @@
 
 #include <grpcpp/grpcpp.h>
 #include <iostream>
+#include "../../core/logging/logger.h"
 
 using grpc::Server;
 using grpc::ServerBuilder;
 
 int main(int argc, char** argv) {
 	(void)argc; (void)argv;
+	(void)sonet::logging::init_json_stdout_logger();
+	spdlog::info(R"({"event":"startup","message":"Starting Sonet Media Service"})");
 	// Natural comments: tune via env/flags later; good defaults for dev
 	std::string listen_addr = "0.0.0.0:50053"; // avoid clashing with other services
 	std::string local_store_dir = "/tmp/sonet-media";

--- a/sonet/src/services/messaging_service/main.cpp
+++ b/sonet/src/services/messaging_service/main.cpp
@@ -12,6 +12,7 @@
 #include <cstdlib>
 #include <string>
 #include <vector>
+#include "../../core/logging/logger.h"
 #include "include/messaging_service.hpp"
 
 using namespace sonet::messaging;
@@ -310,6 +311,9 @@ namespace {
 }
 
 int main(int argc, char* argv[]) {
+    // Initialize JSON logger for ELK ingestion
+    (void)sonet::logging::init_json_stdout_logger();
+    spdlog::info(R"({"event":"startup","message":"Starting Sonet Messaging Service"})");
     try {
         // Parse command line arguments
         ServiceConfiguration config;

--- a/sonet/src/services/note_service/main.cpp
+++ b/sonet/src/services/note_service/main.cpp
@@ -10,6 +10,7 @@
 #include <iostream>
 #include <csignal>
 #include <memory>
+#include "../../core/logging/logger.h"
 
 /**
  * @brief Main entry point for the Twitter-Scale Note Service
@@ -134,6 +135,8 @@ void print_service_info() {
 }
 
 int main(int argc, char* argv[]) {
+    (void)sonet::logging::init_json_stdout_logger();
+    spdlog::info(R"({"event":"banner","service":"note","message":"Sonet Note Service starting"})");
     try {
         // Print startup banner
         print_startup_banner();

--- a/sonet/src/services/notification_service/main.cpp
+++ b/sonet/src/services/notification_service/main.cpp
@@ -10,6 +10,7 @@
 
 #include "service.h"
 #include <iostream>
+#include "../../core/logging/logger.h"
 #include <csignal>
 #include <memory>
 #include <thread>
@@ -209,17 +210,9 @@ NotificationServiceConfig load_configuration(int argc, char* argv[]) {
  * Setup logging based on environment
  */
 void setup_logging(const std::string& environment) {
-    const char* log_level = std::getenv("SONET_LOG_LEVEL");
-    std::string level = log_level ? log_level : "info";
-    
-    if (environment == "development") {
-        level = "debug";
-    } else if (environment == "testing") {
-        level = "warn";
-    }
-    
-    // Here you would setup your logging framework
-    std::cout << "Log level set to: " << level << std::endl;
+    (void)environment;
+    (void)sonet::logging::init_json_stdout_logger();
+    spdlog::info(R"({"event":"startup","message":"Notification logging initialized"})");
 }
 
 /**

--- a/sonet/src/services/search_service/main.cpp
+++ b/sonet/src/services/search_service/main.cpp
@@ -19,6 +19,7 @@
 #include <thread>
 #include <future>
 #include <getopt.h>
+#include "../../core/logging/logger.h"
 
 using namespace sonet::search_service;
 
@@ -309,6 +310,11 @@ void print_startup_status(SearchService* service) {
 int main(int argc, char* argv[]) {
     // Setup signal handlers
     setup_signal_handlers();
+
+    // Initialize JSON logger
+    (void)sonet::logging::init_json_stdout_logger();
+    spdlog::info(R"({"event":"startup","message":"Starting Sonet Search Service"})");
+    spdlog::info(R"({"event":"banner","service":"search","message":"Sonet Search Service starting"})");
     
     // Parse command line arguments
     std::string config_file;

--- a/sonet/src/services/timeline_service/main.cpp
+++ b/sonet/src/services/timeline_service/main.cpp
@@ -13,6 +13,7 @@
 #include <string>
 #include <thread>
 #include <csignal>
+#include "../../core/logging/logger.h"
 
 namespace {
     std::unique_ptr<grpc::Server> server;
@@ -27,12 +28,16 @@ namespace {
 }
 
 int main(int argc, char** argv) {
+    // Initialize JSON logger for ELK ingestion
+    (void)sonet::logging::init_json_stdout_logger();
+    spdlog::info(R"({"event":"startup","message":"Starting Sonet Timeline Service"})");
     // Set up signal handlers
     std::signal(SIGINT, SignalHandler);
     std::signal(SIGTERM, SignalHandler);
 
-    std::cout << "=== Sonet Timeline Service ===" << std::endl;
-    std::cout << "Starting advanced timeline service with Twitter-scale engineering..." << std::endl;
+    // std::cout banners replaced with structured logs for ELK
+    spdlog::info(R"({"event":"banner","service":"timeline","message":"Sonet Timeline Service starting"})");
+    spdlog::info(R"({"event":"info","service":"timeline","message":"Starting advanced timeline service with Twitter-scale engineering"})");
 
     // Parse command line arguments
     std::string server_address = "0.0.0.0:50051";

--- a/sonet/src/services/user_service/src/main.cpp
+++ b/sonet/src/services/user_service/src/main.cpp
@@ -9,6 +9,7 @@
 #include "user_service.h"
 #include <grpcpp/grpcpp.h>
 #include <spdlog/spdlog.h>
+#include "../../../core/logging/logger.h"
 #include <csignal>
 #include <memory>
 #include <cstdlib>
@@ -28,11 +29,9 @@ void signal_handler(int signal) {
 }
 
 int main(int argc, char* argv[]) {
-    // Set up logging - I want to see everything that's happening
-    spdlog::set_level(spdlog::level::info);
-    spdlog::set_pattern("[%Y-%m-%d %H:%M:%S.%e] [%l] %v");
-    
-    spdlog::info("Starting Sonet User Service...");
+    // Initialize JSON logger for ELK ingestion
+    (void)sonet::logging::init_json_stdout_logger();
+    spdlog::info(R"({"event":"startup","message":"Starting Sonet User Service"})");
     
     // Set up signal handlers for graceful shutdown
     std::signal(SIGINT, signal_handler);


### PR DESCRIPTION
Integrates ELK Stack and Beats for centralized logging and monitoring of Sonet services.

This PR introduces Elasticsearch, Kibana, Logstash, Filebeat, and Metricbeat via Docker Compose. Filebeat collects Docker container logs, which are then processed by Logstash (prioritizing JSON parsing) and sent to Elasticsearch. Metricbeat collects system and Docker metrics. Additionally, core C++ services are updated to output structured JSON logs, improving log analysis in Kibana.

---
<a href="https://cursor.com/background-agent?bcId=bc-045b458a-9fda-4ba4-99eb-ec213a8056dc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-045b458a-9fda-4ba4-99eb-ec213a8056dc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

