### PR TITLE
Debug failing process

### DIFF
--- a/sonet-client/webpack.config.js
+++ b/sonet-client/webpack.config.js
@@ -33,6 +33,7 @@ module.exports = async function (env, argv) {
   config.resolve = config.resolve || {}
   config.resolve.alias = {
     ...(config.resolve.alias || {}),
+    '#': path.resolve(__dirname, 'src'),
     '@sonet/api': path.resolve(__dirname, 'src/api/sonet-client.ts'),
     '@sonet/types': path.resolve(__dirname, 'src/types/sonet.ts'),
   }


### PR DESCRIPTION
Add `#` alias to webpack config to resolve web build import errors.

The web build was failing because webpack did not recognize the `#/App` import alias, which was only configured in Babel. This change ensures webpack resolves `#/App` to `./src/App.web.tsx` for web builds, aligning with the existing Babel configuration for native builds.

---
<a href="https://cursor.com/background-agent?bcId=bc-2f17d4f5-84e1-4a7a-ad83-8bcee7f4dc21">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2f17d4f5-84e1-4a7a-ad83-8bcee7f4dc21">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

