### PR TITLE
Investigate client directory errors

### DIFF
--- a/sonet-client/src/lib/strings/usernames.ts
+++ b/sonet-client/src/lib/strings/usernames.ts
@@ -1,0 +1,1 @@
+export * from './handles'

--- a/sonet-client/webpack.config.js
+++ b/sonet-client/webpack.config.js
@@ -10,7 +10,8 @@ const GENERATE_STATS = process.env.EXPO_PUBLIC_GENERATE_STATS === '1'
 const OPEN_ANALYZER = process.env.EXPO_PUBLIC_OPEN_ANALYZER === '1'
 
 const reactNativeWebWebviewConfiguration = {
-  test: /noteMock.html$/,
+  // Load the mock HTML file that react-native-web-webview imports on web
+  test: /postMock.html$/,
   use: {
     loader: 'file-loader',
     options: {


### PR DESCRIPTION
Fixes module resolution for `usernames` and corrects Webpack rule for `postMock.html`.

The `usernames` import was failing because the code was located in `handles.ts`, so a shim was added to resolve the import. The `postMock.html` file was being incorrectly parsed as JavaScript because the Webpack rule was mistakenly configured to match `noteMock.html`. The regex has been corrected to ensure `postMock.html` is handled by `file-loader`.

---
<a href="https://cursor.com/background-agent?bcId=bc-656995c6-e1bb-45fb-87e2-75b664cbf8c7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-656995c6-e1bb-45fb-87e2-75b664cbf8c7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

