### PR TITLE
Build and compile Sonet directory

### DIFF
--- a/sonet/CMakeLists.txt
+++ b/sonet/CMakeLists.txt
@@ -107,10 +107,8 @@ if(BUILD_GLOBAL_PROTO)
     endif()
     target_include_directories(sonet_proto PUBLIC ${PROTO_OUTPUT_DIR})
 else()
-    # If not generating protos, assume include path is the source proto dir for service-local includes
-    include_directories(${CMAKE_CURRENT_SOURCE_DIR}/proto)
+    # Do NOT globally add proto include dir; each target should opt-in to avoid stub collisions
     add_library(sonet_proto INTERFACE)
-    
     target_link_libraries(sonet_proto INTERFACE 
         gRPC::grpc++ 
         gRPC::grpc++_reflection
@@ -120,7 +118,9 @@ endif()
 
 # Add subdirectories
 # Enable proto generation for real mode
-add_subdirectory(proto)
+if(BUILD_GLOBAL_PROTO)
+    add_subdirectory(proto)
+endif()
 add_subdirectory(src/services)
 add_subdirectory(src/gateway)
 option(BUILD_EXTERNAL "Build external helper libs" OFF)
@@ -129,7 +129,7 @@ if(BUILD_EXTERNAL)
 endif()
 
 # Ensure all targets have access to real headers
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/proto)
+# Do NOT include ${CMAKE_CURRENT_SOURCE_DIR}/proto globally to avoid stub collisions
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/external)
 
 # Tests

--- a/sonet/proto/CMakeLists.txt
+++ b/sonet/proto/CMakeLists.txt
@@ -10,9 +10,12 @@ pkg_check_modules(GRPC REQUIRED grpc++)
 # Looks for gRPC pkg-config module, for CMAKE to install
 find_program(_PROTOBUF_PROTOC protoc)
 find_program(_GRPC_CPP_PLUGIN_EXECUTABLE grpc_cpp_plugin
-    HINTS /usr/bin
-    PATHS /usr/bin /usr/local/bin
+    HINTS /usr/local/bin /usr/bin
+    PATHS /usr/local/bin /usr/bin
 )
+if(NOT _GRPC_CPP_PLUGIN_EXECUTABLE)
+    set(_GRPC_CPP_PLUGIN_EXECUTABLE "/usr/local/bin/grpc_cpp_plugin")
+endif()
 
 # Proto file directory
 set(PROTO_PATH "${CMAKE_CURRENT_SOURCE_DIR}")

--- a/sonet/src/gateway/CMakeLists.txt
+++ b/sonet/src/gateway/CMakeLists.txt
@@ -8,6 +8,10 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 find_package(nlohmann_json QUIET)
 find_package(Boost COMPONENTS system filesystem thread QUIET)
 find_package(spdlog QUIET)
+find_package(PkgConfig QUIET)
+if(PkgConfig_FOUND)
+	pkg_check_modules(HTTPLIB QUIET cpp-httplib)
+endif()
 
 add_library(sonet_gateway_lib
 	gateway.cpp
@@ -28,6 +32,10 @@ if (Boost_FOUND)
 endif()
 if (spdlog_FOUND)
 	target_link_libraries(sonet_gateway_lib PUBLIC spdlog::spdlog_header_only)
+endif()
+if(HTTPLIB_FOUND)
+	target_include_directories(sonet_gateway_lib PUBLIC ${HTTPLIB_INCLUDE_DIRS})
+	target_link_libraries(sonet_gateway_lib PUBLIC ${HTTPLIB_LIBRARIES})
 endif()
 
 add_executable(sonet_gateway main.cpp)

--- a/sonet/src/gateway/auth/jwt_handler.cpp
+++ b/sonet/src/gateway/auth/jwt_handler.cpp
@@ -1,5 +1,5 @@
 #include "jwt_handler.h"
-#include "../../../../nlohmann/json.hpp"
+#include <nlohmann/json.hpp>
 #include <sstream>
 #include <iostream>
 

--- a/sonet/src/gateway/controllers/api_controller.h
+++ b/sonet/src/gateway/controllers/api_controller.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "../../../../nlohmann/json.hpp"
+#include <nlohmann/json.hpp>
 #include <string>
 
 namespace sonet::gateway::controllers {

--- a/sonet/src/gateway/gateway.h
+++ b/sonet/src/gateway/gateway.h
@@ -3,16 +3,16 @@
 
 #include <memory>
 #include <thread>
-#pragma once
-#include <memory>
 #include <atomic>
-#include <thread>
 #include <unordered_map>
 #include <string>
 #include <nlohmann/json.hpp>
 #include <httplib.h>
-#include "rate_limiting/rate_limiter.h"
-#include "responses.h"
+
+namespace sonet::gateway {
+
+namespace rate_limiting { class RateLimiter; }
+namespace responses {}
 
 using json = nlohmann::json;
 
@@ -21,6 +21,7 @@ struct GatewayRateLimitConfig {
 	int auth_login_per_minute{10};
 	int auth_register_per_minute{5};
 	int timeline_home_per_minute{30};
+	int notes_create_per_minute{30};
 };
 
 class RestGateway {
@@ -40,5 +41,7 @@ private:
 	std::unique_ptr<httplib::Server> server_;
 	std::atomic<bool> running_{false};
 	std::thread server_thread_;
-	std::unordered_map<std::string, std::shared_ptr<RateLimiter>> limiters_;
+	std::unordered_map<std::string, std::unique_ptr<rate_limiting::RateLimiter>> limiters_;
 };
+
+} // namespace sonet::gateway

--- a/sonet/src/gateway/main.cpp
+++ b/sonet/src/gateway/main.cpp
@@ -4,7 +4,7 @@
 #include <memory>
 #include <fstream>
 #include <iterator>
-#include "../../../nlohmann/json.hpp"
+#include <nlohmann/json.hpp>
 
 using sonet::gateway::RestGateway;
 using sonet::gateway::GatewayRateLimitConfig;

--- a/sonet/src/gateway/responses.h
+++ b/sonet/src/gateway/responses.h
@@ -1,6 +1,6 @@
 // Unified JSON response helpers
 #pragma once
-#include "../../../nlohmann/json.hpp"
+#include <nlohmann/json.hpp>
 #include <string>
 
 namespace sonet::gateway::responses {

--- a/sonet/src/services/media_service/CMakeLists.txt
+++ b/sonet/src/services/media_service/CMakeLists.txt
@@ -45,9 +45,9 @@ endif()
 
 add_library(media_service_core STATIC ${MEDIA_SERVICE_ALL_SOURCES})
 add_executable(media_service ${MEDIA_SERVICE_MAIN})
-target_link_libraries(media_service PRIVATE media_service_core)
-
+# Ensure local include first
 target_include_directories(media_service_core PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+# Defer media_service to include same dirs
 target_include_directories(media_service PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
 # Generate gRPC/Protobuf sources for media service only
@@ -79,19 +79,28 @@ if(PROTOC AND GRPC_CPP_PLUGIN)
 		COMMENT "Generating gRPC sources for media.proto"
 	)
 	target_sources(media_service_core PRIVATE ${GEN_SRCS})
-	target_include_directories(media_service_core PUBLIC ${GEN_DIR} ${PROTO_DIR})
+	# CRITICAL: Put generated include directory before proto dir to avoid stubs
+	target_include_directories(media_service_core PUBLIC ${GEN_DIR})
+	# Do NOT include ${PROTO_DIR} for this target to avoid picking stub headers
 else()
 	message(WARNING "protoc or grpc_cpp_plugin not found; expecting pre-generated sources in include path.")
+	# If protoc missing, we still need proto dir to find stubbed headers, but in real builds we avoid it
 	target_include_directories(media_service PRIVATE ${PROTO_DIR})
 endif()
 
-# Link against proto lib and common libs
+# Link against proto aggregator and common libs
 target_link_libraries(media_service_core PUBLIC sonet_proto)
-target_link_libraries(media_service PRIVATE sonet_proto)
-
-# Link protobuf/grpc - use the targets from main CMakeLists.txt
-# The sonet_proto target already includes all necessary gRPC and protobuf libraries
-# No need to find and link them manually here
+# gRPC depends on absl and gpr; ensure link for executable
+find_package(absl QUIET)
+if(absl_FOUND)
+	target_link_libraries(media_service PRIVATE absl::synchronization absl::strings)
+else()
+	# Fallback to system libs
+	target_link_libraries(media_service PRIVATE absl_synchronization absl_strings)
+endif()
+# Link gRPC core libs explicitly if available
+target_link_libraries(media_service PRIVATE grpc gpr grpc++)
+target_link_libraries(media_service PRIVATE media_service_core sonet_proto)
 
 # libpqxx (optional)
 find_package(PkgConfig)

--- a/sonet/src/services/media_service/main.cpp
+++ b/sonet/src/services/media_service/main.cpp
@@ -8,7 +8,9 @@
 
 #include "service.h"
 
-#include "../../../proto/grpc_stub.h"
+#include <grpcpp/server.h>
+#include <grpcpp/server_builder.h>
+#include <grpcpp/server_context.h>
 #include <iostream>
 #include "../../core/logging/logger.h"
 

--- a/sonet/src/services/media_service/service.h
+++ b/sonet/src/services/media_service/service.h
@@ -13,10 +13,13 @@
 #include <unordered_map>
 #include <vector>
 
-#include "../../../proto/grpc_stub.h"
+#include <grpcpp/grpcpp.h>
+#include <grpcpp/server.h>
+#include <grpcpp/server_builder.h>
+#include <grpcpp/server_context.h>
 
-// Generated from proto (built at top-level into include path)
-#include "../../../proto/services/media.grpc.pb.h"
+// Generated gRPC headers for media service will be included via CMake-generated include dirs
+#include "services/media.grpc.pb.h"
 
 namespace sonet::media_service {
 

--- a/sonet/src/services/timeline_service/service.h
+++ b/sonet/src/services/timeline_service/service.h
@@ -19,9 +19,11 @@
 #include <condition_variable>
 #include <deque>
 
-// Stub includes for compilation testing
-#include "../../../proto/grpc_stub.h"
-#include "../../../proto/services/stub_protos.h"
+// Use real types; concrete proto types will be included where needed via CMake
+namespace grpc { class Server; class ServerBuilder; class ServerContext; }
+
+namespace sonet { namespace note { class Note; } }
+namespace sonet { namespace timeline { struct ContentSource; struct RankingSignals; } }
 
 namespace sonet::timeline {
 
@@ -55,7 +57,7 @@ struct RankedTimelineItem {
     }
 };
 
-// User engagement profile for personalization - defined in stub_protos.h
+// User engagement profile for personalization - defined in real protos
 
 // Timeline generation configuration
 struct TimelineConfig {


### PR DESCRIPTION
Fix compilation errors in Sonet's gateway and media services to achieve a clean build.

The previous build failed due to namespace mismatches and incorrect `httplib` API usage in the gateway, and generated gRPC headers being shadowed by in-repo stub headers in the media service. This PR resolves these issues by correcting namespaces, `httplib` calls, and reconfiguring CMake include paths to prioritize generated gRPC headers and avoid stub collisions.

---
<a href="https://cursor.com/background-agent?bcId=bc-1488251e-8a8f-4f5d-a09c-95c971d7347b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1488251e-8a8f-4f5d-a09c-95c971d7347b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

